### PR TITLE
Remove scheduled docker build and add docker-compose.dev.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,19 +6,14 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: '21 5 * * *'
   push:
     branches: [ "develop" ]
-    # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "develop" ]
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
 
@@ -29,21 +24,11 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
-        with:
-          cosign-release: 'v2.2.4'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
@@ -81,18 +66,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
-          TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ stage
 include/mpdf/ttfontdata
 include/mpdf/tmp
 nbproject/
+
+# Ignore docker compose mysql data
+mysql/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,35 @@
+version: '3.6'
+
+services:
+  osticket:
+    build: .
+    ports:
+      - 8080:80
+    environment:
+      - DB_HOST=mysql
+      - DB_USER=changeme
+      - DB_PASS=changeme
+      - DB_NAME=changeme
+      - ADMIN_PASS=password1
+      - ADMIN_EMAIL=test@example.com
+      - ADMIN_USER=TestUser
+      - ADMIN_FIRSTNAME=test
+      - ADMIN_LASTNAME=test
+      - INSTALL_SECRET=123123123123123123123
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    links:
+      - mysql:mysql
+
+  mysql:
+    image: mariadb
+    volumes:
+      - ./mysql:/var/lib/mysql
+    tmpfs:
+      - /tmp
+      - /var/lock
+    environment:
+      - MYSQL_USER=changeme
+      - MYSQL_PASSWORD=changeme
+      - MYSQL_DATABASE=changeme
+      - MYSQL_ROOT_PASSWORD=changeme


### PR DESCRIPTION
The docker image was building not only just on push, but on a schedule. This was unnecessary. I also removed cosign so images build faster, the minor added security is not necessary for our small repo. docker-compose.dev.yml can be used to reproducibly test the program with `docker compose -f docker-compose.dev.yml up`.